### PR TITLE
feat: switch to SDR-E action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,37 +5,34 @@ on:
     inputs:
       reason:
         required: true
-        description: 'Reason for running this workflow'
+        description: "Reason for running this workflow"
   push:
     branches:
       - master
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 jobs:
   build:
-    name: 'Build'
-    runs-on: ubuntu-latest
-    steps:
-    - name: "Build:checkout"
-      uses: actions/checkout@v3
-
-    - name: "Build:qemu"
-      uses: docker/setup-qemu-action@v2
-
-    - name: "Build:buildx"
-      uses: docker/setup-buildx-action@v2
-
-    - name: "Build:login"
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: 'Build:buildandpush'
-      uses: docker/build-push-action@v3.0.0
-      with:
-        push: true
-        platforms: linux/amd64,linux/arm/v7,linux/arm64
-        tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ github.run_number }}-${{ github.sha }}
+    name: Build
+    uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@main
+    permissions:
+      id-token: "write"
+      contents: "read"
+      attestations: "write"
+      packages: "write"
+    with:
+      push_enabled: true
+      push_destinations: ghcr.io
+      ghcr_repo_owner: ${{ github.repository_owner }}
+      ghcr_repo: ${{ github.repository }}
+      # set build_latest to true if github.event.inputs.use_test_image is false
+      build_latest: true
+      build_baseimage_test: ${{ github.event.inputs.use_test_image == 'true' }}
+      # needed to make the action work, but not used
+      build_baseimage_url: :base/:base-test-pr
+      platform_linux_amd64_enabled: true
+      platform_linux_arm64v8_enabled: true
+      platform_linux_arm32v7_enabled: true
+    secrets:
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Switching to the SDR-E github action will enable native runners to do the build.

Builds will auto-tag with `latest` and `latest-build-X` with X being the run number.

Your build time on this wasn't terribly long, anyway, but this cuts the build time in about half.