### PR TITLE
(fix) trust acars decoder

### DIFF
--- a/rootfs/scripts/acars2pos.py
+++ b/rootfs/scripts/acars2pos.py
@@ -189,9 +189,6 @@ while True:
       if not sbs.get("txt"):
         continue
 
-      if sbs["txt"].lstrip().startswith("FPN/") or sbs["txt"].lstrip().startswith("PWI/"):
-        continue
-
       if getenv("LOG_FILE") and sbs.get("msgtype") and sbs.get("type") != "hfdl":
         with open(f"/log/nopos.log", "a", 1) as logfile:
           logfile.write(f'{sbs["type"]}\t{sbs.get("msgtype")}\thttps://globe.adsbexchange.com/?icao={sbs["icao"]}&showTrace={datetime.fromtimestamp(sbs["time"], tz=timezone.utc):%Y-%m-%d}&timestamp={sbs["time"]}\n')

--- a/rootfs/scripts/acars_decode/Decoder.py
+++ b/rootfs/scripts/acars_decode/Decoder.py
@@ -174,6 +174,12 @@ def decode(msg):
     if res and res.decoded and res.raw:
 #      print("airframes")
       dat["squawk"] += 100
+      if res.raw.tail:
+        dat["reg"] = res.raw.tail
+      if res.raw.flight_number:
+        dat["flight"] = res.raw.flight_number
+      if res.raw.message_timestamp: # acars can be delayed. use the actual message instead of reception time
+        dat["time"] = res.raw.message_timestamp
       if res.raw.position:
 #        print("airframes pos")
         dat["squawk"] += 100
@@ -187,7 +193,6 @@ def decode(msg):
         dat["ground"] = True
       if res.raw.off_time:
         dat["ground"] = False
-    if res and res.decoded:
       return dat
 
   if not dat or not dat.get("txt"): # or dat.get("lat"):

--- a/rootfs/scripts/acars_decode/Decoder.py
+++ b/rootfs/scripts/acars_decode/Decoder.py
@@ -187,15 +187,11 @@ def decode(msg):
         dat["ground"] = True
       if res.raw.off_time:
         dat["ground"] = False
-#    else:
-#      if res.decoder.decodeLevel in ["none"]: # , "partial"]:
-#        nonaf[dat["msgtype"]] = nonaf.get(dat["msgtype"], 0) + 1
-#        print(nonaf)
+    if res and res.decoded:
+      return dat
 
   if not dat or not dat.get("txt"): # or dat.get("lat"):
     return dat
-
-  #dat["txt"] = dat.get("txt", "").upper().replace("\r", "").replace("\n", "")
 
   rgxl = msgrgx.get(dat.get("msgtype"))
   if rgxl and dat.get("msgtype"):


### PR DESCRIPTION
Instead of filtering out messages that might have lat/lon that do not correspond to the aircraft position, do not run the regex if the decoder library successfully decodes the message.

If false positives are found in the regex, a decoder can be added to @airframes/acars-decoder