### PR TITLE
Update acars2pos.py

### DIFF
--- a/rootfs/scripts/acars2pos.py
+++ b/rootfs/scripts/acars2pos.py
@@ -189,7 +189,7 @@ while True:
       if not sbs.get("txt"):
         continue
 
-      if sbs["txt"].lstrip().startswith("FPN/") or sbs["txt"].lstrip().startswith("PWI/"):
+      if "FPN/" in sbs["txt"] or "PWI/" in sbs["txt"]:
         continue
 
       if getenv("LOG_FILE") and sbs.get("msgtype") and sbs.get("type") != "hfdl":


### PR DESCRIPTION
After the last change someone on the SDR Enthusiasts Discord mentioned that sometimes these strings can be in the middle of a message. 

This F11A message on airframes demonstrates it well: https://app.airframes.io/messages/6552027033

Hopefully this fixes that.